### PR TITLE
fixed out-of-bounds index when using empty.db.  

### DIFF
--- a/src/logic/clause.h
+++ b/src/logic/clause.h
@@ -298,7 +298,12 @@ class Clause
   bool isDirty() const { return dirty_; }
 
     // Caller should not delete returned Predicate*.
-  Predicate* getPredicate(const int& idx) const { return (*predicates_)[idx]; }
+  Predicate* getPredicate(const int& idx) const { 
+    if (idx > 0 && idx < getNumPredicates()){
+      return (*predicates_)[idx]; 
+    }
+    else return NULL;
+  }
   
     // Caller should not delete returned array nor modify its contents.
   const Array<Predicate*>* getPredicates() const { return predicates_; }

--- a/src/logic/database.h
+++ b/src/logic/database.h
@@ -1057,6 +1057,9 @@ class Database
                          bool const & ignoreActivePreds,
                          bool const & trueGndings)
   {
+    if (pred == NULL){
+        return; // nothing to do here
+    }
     int predId = pred->getId();
       // All terms are grounded: just return itself
     if (pred->isGrounded())


### PR DESCRIPTION
now the basic tutorials run.  there is still a memory leak. after the uniform.mln tutorial valgrind tells me:
==10503== 
==10503== HEAP SUMMARY:
==10503==     in use at exit: 31,191 bytes in 193 blocks
==10503==   total heap usage: 23,236 allocs, 23,043 frees, 627,961 bytes allocated
==10503== 
==10503== LEAK SUMMARY:
==10503==    definitely lost: 832 bytes in 7 blocks
==10503==    indirectly lost: 10,322 bytes in 163 blocks
==10503==      possibly lost: 0 bytes in 0 blocks
==10503==    still reachable: 20,037 bytes in 23 blocks
==10503==         suppressed: 0 bytes in 0 blocks
==10503== Rerun with --leak-check=full to see details of leaked memory
==10503== 
==10503== For counts of detected and suppressed errors, rerun with: -v
==10503== Use --track-origins=yes to see where uninitialised values come from
==10503== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
