### PR TITLE
guards for null predicate pointer.

### DIFF
--- a/src/infer/mrf.h
+++ b/src/infer/mrf.h
@@ -437,7 +437,7 @@ class MRF
     {
       for (int i = 0; i < c->getNumPredicates(); i++)
       {
-        if (c->getPredicate(i)->canBeGroundedAs(queryGndPred))
+        if (c->getPredicate(i) != NULL && c->getPredicate(i)->canBeGroundedAs(queryGndPred))
           c->addUnknownClauses(domain, db, i, queryGndPred, agcs);
       }
     }

--- a/src/parser/folhelper.h
+++ b/src/parser/folhelper.h
@@ -1901,7 +1901,7 @@ void zzaddGndPredsToDb(Database* const & db)
     for (int j = 0; j < clause->getNumPredicates(); j++)
     {
       Predicate* pred = clause->getPredicate(j);
-      if (!db->isClosedWorld(pred->getId()))
+      if (pred && !db->isClosedWorld(pred->getId()))
       {
         nonEvidPred[j] = true;
         oneNonEvidPred = true;


### PR DESCRIPTION
The binomial tutorial would crash due to dereferencing a null pointer for predicate.  This merge request fixes that crash.